### PR TITLE
Fixed backend not programming boards with a Workaround nodejs' feature

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -106,19 +106,21 @@ then
 
     # Install node modules
     npm install
-    
+
     # Configure start file
     echo "#!/bin/bash" > start.sh
     echo "$work_dir/node_modules/electron/dist/electron $work_dir/Blockly-for-Dwenguino/index.html --no-sandbox &" >> start.sh # Start electron
     echo 'electronPid=$!' >> start.sh # get process id for the latest command
-    echo "node --experimental-modules $work_dir/backend/index.js &" >> start.sh # start backend
+    echo "cd $work_dir/backend/" >> start.sh # for some weird reason we have to be inside the folder, before calling node to run the js file
+    echo "node --experimental-modules index.js &" >> start.sh # start the backend
+    echo "cd $work_dir" >> start.sh # and go back to wherever you came from
     echo 'nodePid=$!' >> start.sh # get the process id for the latest command
     echo 'echo "DwenguinoBlockly is running"' >> start.sh
     echo 'wait $electronPid' >> start.sh # Wait until electron environment is closed
     echo 'kill $nodePid' >> start.sh # Kill the backend application
     echo 'echo "Quitting DwenguinoBlockly"' >> start.sh
     chmod +x start.sh
-    
+
     # Configure make binaries
     rm ./backend/compilation/bin/make
     cp ./backend/compilation/bin/linux/make ./backend/compilation/bin/make
@@ -167,17 +169,19 @@ then
     echo "#!/bin/bash" > dwenguinoblockly.command
     echo "$work_dir/node_modules/electron/dist/electron $work_dir/Blockly-for-Dwenguino/index.html --no-sandbox &" >> dwenguinoblockly.command # Start electron
     echo 'electronPid=$!' >> dwenguinoblockly.command # get process id for the latest command
-    echo "node --experimental-modules $work_dir/backend/index.js &" >> dwenguinoblockly.command # start backend
+    echo "cd $work_dir/backend/" >> dwenguinoblockly.command # for some weird reason we have to be inside the folder, before calling node to run the js file
+    echo "node --experimental-modules index.js &" >> dwenguinoblockly.command # start the backend
+    echo "cd $work_dir" >> dwenguinoblockly.command # and go back to wherever you came from
     echo 'nodePid=$!' >> dwenguinoblockly.command # get the process id for the latest command
     echo 'echo "DwenguinoBlockly is running"' >> dwenguinoblockly.command
     echo 'wait $electronPid' >> dwenguinoblockly.command # Wait until electron environment is closed
     echo 'kill $nodePid' >> dwenguinoblockly.command # Kill the backend application
     echo 'echo "Quitting DwenguinoBlockly"' >> dwenguinoblockly.command
     chmod +x dwenguinoblockly.command
-    
+
     # Copy start file to desktop
     cp dwenguinoblockly.command ~/Desktop
-    
+
     # Install node modules
     npm install --save electron-prebuilt
     npm install


### PR DESCRIPTION
For some weird reason we have to be inside the folder, before calling node to run the js file